### PR TITLE
set/reset efm

### DIFF
--- a/plugin/valgrind.vim
+++ b/plugin/valgrind.vim
@@ -57,6 +57,8 @@ function s:Valgrind(...)
     execute run_valgrind
     call s:ExtractError(tmpfilexml, tmpfileerror)
 
+    let efm = &l:efm
     setlocal errorformat=%n:%f:%l:%m
     execute "cfile ".tmpfileerror
+    let &l:efm = efm
 endfunction


### PR DESCRIPTION
I believe this addresses the issue in which a call to Valgrind overrites the
errorformat and affects subsequent calls to make. This saves the original
value of efm and resets it after the call.
